### PR TITLE
store JWT accessToken in a cookie

### DIFF
--- a/src/main/java/com/vinland/store/security/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/vinland/store/security/auth/controller/AuthenticationController.java
@@ -7,7 +7,9 @@ import com.vinland.store.security.auth.service.AuthenticationService;
 import com.vinland.store.utils.MessageResponse;
 import com.vinland.store.utils.PathConstants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,8 +21,16 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @PostMapping(value = "/sign-in", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public LoginResponse signInUser(@ModelAttribute LoginRequest loginRequest) {
-        return authenticationService.signIn(loginRequest.getEmail(), loginRequest.getPassword());
+    public ResponseEntity<LoginResponse> signInUser(@ModelAttribute LoginRequest loginRequest) {
+        final LoginResponse response = authenticationService.signIn(loginRequest.getEmail(), loginRequest.getPassword());
+        final String cleanedAccessToken = response.getAccessToken().substring("Bearer ".length());
+        ResponseCookie cookie = ResponseCookie.from("accessToken", cleanedAccessToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .build();
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(response);
     }
 
     @PostMapping(value = "/sign-up", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)


### PR DESCRIPTION
For more secure storage of access tokens, consider HttpOnly cookies with the Secure and SameSite attributes. HttpOnly ensures that client-side scripts cannot access the token, preventing XSS attacks, while Secure ensures the token is only sent over HTTPS.

